### PR TITLE
Implement remainder of chat API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pro.beam</groupId>
     <artifactId>api</artifactId>
-    <version>1.6.11-SNAPSHOT</version>
+    <version>1.6.12-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/pro/beam/api/exceptions/BadRequest.java
+++ b/src/main/java/pro/beam/api/exceptions/BadRequest.java
@@ -1,0 +1,4 @@
+package pro.beam.api.exceptions;
+
+public class BadRequest extends BeamException {
+}

--- a/src/main/java/pro/beam/api/exceptions/Forbidden.java
+++ b/src/main/java/pro/beam/api/exceptions/Forbidden.java
@@ -1,0 +1,4 @@
+package pro.beam.api.exceptions;
+
+public class Forbidden extends BeamException {
+}

--- a/src/main/java/pro/beam/api/exceptions/channel/ChannelNotFound.java
+++ b/src/main/java/pro/beam/api/exceptions/channel/ChannelNotFound.java
@@ -1,0 +1,6 @@
+package pro.beam.api.exceptions.channel;
+
+import pro.beam.api.exceptions.BeamException;
+
+public class ChannelNotFound extends BeamException {
+}

--- a/src/main/java/pro/beam/api/futures/checkers/Chats.java
+++ b/src/main/java/pro/beam/api/futures/checkers/Chats.java
@@ -1,0 +1,26 @@
+package pro.beam.api.futures.checkers;
+
+import com.google.common.collect.ImmutableMap;
+import pro.beam.api.exceptions.BadRequest;
+import pro.beam.api.exceptions.BeamException;
+import pro.beam.api.exceptions.Forbidden;
+import pro.beam.api.exceptions.channel.ChannelNotFound;
+import pro.beam.api.futures.SimpleFutureChecker;
+import pro.beam.api.response.chat.ChatSettingsResponse;
+
+public class Chats {
+    private static final int BAD_REQUEST_RESPONSE = 400;
+    private static final int FORBIDDEN_RESPONSE = 403;
+    private static final int CHANNEL_NOT_FOUND = 404;
+
+    public static class UpdateSettingsChecker extends SimpleFutureChecker<ChatSettingsResponse, BeamException> {
+        public UpdateSettingsChecker() {
+            super(ImmutableMap.of(
+                    BAD_REQUEST_RESPONSE, BadRequest.class,
+                    FORBIDDEN_RESPONSE, Forbidden.class,
+                    CHANNEL_NOT_FOUND, ChannelNotFound.class
+                )
+            );
+        }
+    }
+}

--- a/src/main/java/pro/beam/api/resource/chat/OnlineChatUser.java
+++ b/src/main/java/pro/beam/api/resource/chat/OnlineChatUser.java
@@ -1,0 +1,11 @@
+package pro.beam.api.resource.chat;
+
+import pro.beam.api.resource.BeamUser;
+
+import java.util.List;
+
+public class OnlineChatUser {
+    public String userName;
+    public List<BeamUser.Role> userRoles;
+    public int userId;
+}

--- a/src/main/java/pro/beam/api/response/chat/ChatSettingsResponse.java
+++ b/src/main/java/pro/beam/api/response/chat/ChatSettingsResponse.java
@@ -1,0 +1,7 @@
+package pro.beam.api.response.chat;
+
+public class ChatSettingsResponse {
+    public boolean linksAllowed;
+    public boolean linksClickable;
+    public int slowchat;
+}

--- a/src/main/java/pro/beam/api/response/chat/MessagesResponse.java
+++ b/src/main/java/pro/beam/api/response/chat/MessagesResponse.java
@@ -1,0 +1,8 @@
+package pro.beam.api.response.chat;
+
+import pro.beam.api.resource.chat.events.data.IncomingMessageData;
+
+import java.util.ArrayList;
+
+public class MessagesResponse extends ArrayList<IncomingMessageData> {
+}

--- a/src/main/java/pro/beam/api/response/chat/OnlineUsersResponse.java
+++ b/src/main/java/pro/beam/api/response/chat/OnlineUsersResponse.java
@@ -1,0 +1,8 @@
+package pro.beam.api.response.chat;
+
+import pro.beam.api.resource.chat.OnlineChatUser;
+
+import java.util.ArrayList;
+
+public class OnlineUsersResponse extends ArrayList<OnlineChatUser> {
+}

--- a/src/main/java/pro/beam/api/services/impl/ChatService.java
+++ b/src/main/java/pro/beam/api/services/impl/ChatService.java
@@ -2,12 +2,65 @@ package pro.beam.api.services.impl;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import pro.beam.api.BeamAPI;
+import pro.beam.api.futures.checkers.Chats;
+import pro.beam.api.http.BeamHttpClient;
+import pro.beam.api.resource.channel.BeamChannel;
 import pro.beam.api.resource.chat.BeamChat;
+import pro.beam.api.response.chat.ChatSettingsResponse;
+import pro.beam.api.response.chat.MessagesResponse;
+import pro.beam.api.response.chat.OnlineUsersResponse;
 import pro.beam.api.services.AbstractHTTPService;
 
 public class ChatService extends AbstractHTTPService {
     public ChatService(BeamAPI beam) {
         super(beam, "chats");
+    }
+
+    public ListenableFuture<MessagesResponse> messages(BeamChannel channel, int start, int end, int limit) {
+        return this.get(String.format("%d/message", channel.id), MessagesResponse.class, BeamHttpClient.getArgumentsBuilder()
+                .put("id", channel.id)
+                .put("start", start)
+                .put("end", end)
+                .put("limit", limit)
+                .build());
+    }
+
+    public ListenableFuture<OnlineUsersResponse> users(BeamChannel channel, int page, int limit) {
+        return this.get(
+                String.format("%d/users", channel.id),
+                OnlineUsersResponse.class,
+                BeamHttpClient.getArgumentsBuilder()
+                    .put("id", channel.id)
+                    .put("page", page)
+                    .put("limit", limit)
+                .build()
+        );
+    }
+
+    public ListenableFuture<OnlineUsersResponse> usersSearch(String username, BeamChannel channel, int page, int limit) {
+        return this.get(
+                String.format("%d/users/search", channel.id),
+                OnlineUsersResponse.class,
+                BeamHttpClient.getArgumentsBuilder()
+                    .put("page", page)
+                    .put("limit", limit)
+                    .put("id", channel.id)
+                    .put("username", username)
+                .build()
+        );
+    }
+
+    public ListenableFuture<ChatSettingsResponse> updateSettings(BeamChannel channel, boolean linksAllowed, boolean linksClickable, int slowchat) {
+        return new Chats.UpdateSettingsChecker().check(this.get(
+                String.format("%d", channel.id),
+                ChatSettingsResponse.class,
+                BeamHttpClient.getArgumentsBuilder()
+                    .put("id", channel.id)
+                    .put("linksAllowed", linksAllowed)
+                    .put("linksClickable", linksClickable)
+                    .put("slowchat", slowchat)
+                .build()
+        ));
     }
 
     public ListenableFuture<BeamChat> findOne(int id) {


### PR DESCRIPTION
This pull-request implements the remainder of the `/chats/` api in V1. It implements the following methods:
- `FindOne<Message>`
- `FindOne<Chat>`
- `FindOne<ChatUser>`
- `FindMany<ChatUser>`
- `PatchOne<Chat>`
- `DeleteOne<ChatMessage>`
- `DeleteMany<ChatMessage>`

Necessary for https://github.com/WatchBeam/Android/issues/9.

---

/to @angelkjos @connor4312 
