### PR TITLE
date adapter: add hack to parse ISO8601 on Android

### DIFF
--- a/src/main/java/pro/beam/api/util/gson/DateAdapter.java
+++ b/src/main/java/pro/beam/api/util/gson/DateAdapter.java
@@ -64,7 +64,7 @@ public class DateAdapter extends TypeAdapter<Date> {
      * @throws IOException See above.
      */
     @Override public Date read(JsonReader r) throws IOException {
-        String str = r.nextString();
+        String str = r.nextString().replace("Z", "+0000");
 
         for (DateFormat format : this.formats) {
             try {
@@ -84,7 +84,7 @@ public class DateAdapter extends TypeAdapter<Date> {
      */
     public static DateAdapter v1() {
         DateFormat defaultFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        DateFormat newFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+        DateFormat newFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
         return new DateAdapter(
                 ImmutableList.of(defaultFormat, newFormat),


### PR DESCRIPTION
Currently, Android's implementation of the `SimpleDAteFormat` class does not
include the format char `X`. On desktop clients, the wildcard `X` token was
being used to ignore the GMT zone signifer `Z`.

This works fine on the desktop, since GMT just means +00:00. On Android,
however, an exception is thrown.

As a temporary workaround, the un-parsable 'Z' is replaced with "+0000", which
is parsable with the `Z` delimiter on both Android and Windows.
