### PR TITLE
support ordering correctly on the channels endpoint

### DIFF
--- a/src/main/java/pro/beam/api/http/SortOrderMap.java
+++ b/src/main/java/pro/beam/api/http/SortOrderMap.java
@@ -4,10 +4,10 @@ import pro.beam.api.util.Enums;
 import pro.beam.api.util.StringUtil;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class SortOrderMap<K,V> extends HashMap<Enum,Enum> {
+public class SortOrderMap<K,V> extends LinkedHashMap<Enum,Enum> {
     public String build() {
         String[] result = new String[this.size()];
         int i = 0;

--- a/src/main/java/pro/beam/api/http/SortOrderMap.java
+++ b/src/main/java/pro/beam/api/http/SortOrderMap.java
@@ -1,0 +1,20 @@
+package pro.beam.api.http;
+
+import pro.beam.api.util.Enums;
+import pro.beam.api.util.StringUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SortOrderMap<K,V> extends HashMap<Enum,Enum> {
+    public String build() {
+        String[] result = new String[this.size()];
+        int i = 0;
+        for (Map.Entry<Enum, Enum> entry : this.entrySet()) {
+            result[i] = Enums.serializedName(entry.getKey()) + ":" +Enums.serializedName(entry.getValue());
+            i++;
+        }
+        return StringUtil.join(Arrays.asList(result),",");
+    }
+}

--- a/src/main/java/pro/beam/api/response/channels/ShowChannelsResponse.java
+++ b/src/main/java/pro/beam/api/response/channels/ShowChannelsResponse.java
@@ -11,7 +11,7 @@ public class ShowChannelsResponse extends ArrayList<BeamChannel> {
         @SerializedName("featured") FEATURED,
         @SerializedName("partnered") PARTNERED,
         @SerializedName("name") NAME,
-        @SerializedName("viewers_total") VIEWERS_TOTAL,
+        @SerializedName("viewersTotal") VIEWERS_TOTAL,
         @SerializedName("followers") FOLLOWERS,
         @SerializedName("subscribers") SUBSCRIBERS,
         @SerializedName("interactive") INTERACTIVE;

--- a/src/main/java/pro/beam/api/services/impl/ChannelsService.java
+++ b/src/main/java/pro/beam/api/services/impl/ChannelsService.java
@@ -7,6 +7,7 @@ import pro.beam.api.BeamAPI;
 import pro.beam.api.exceptions.BeamException;
 import pro.beam.api.futures.checkers.Channels;
 import pro.beam.api.http.BeamHttpClient;
+import pro.beam.api.http.SortOrderMap;
 import pro.beam.api.resource.channel.BeamChannel;
 import pro.beam.api.resource.BeamUser;
 import pro.beam.api.response.channels.ChannelStatusResponse;
@@ -24,20 +25,13 @@ public class ChannelsService extends AbstractHTTPService {
         super(beam, "channels");
     }
 
-    public ListenableFuture<ShowChannelsResponse> show(Map<ShowChannelsResponse.Attributes, ShowChannelsResponse.Ordering> attributes,
-                                                       ShowChannelsResponse.Ordering only,
+    public ListenableFuture<ShowChannelsResponse> show(SortOrderMap<ShowChannelsResponse.Attributes, ShowChannelsResponse.Ordering> ordering,
                                                        int page,
                                                        int limit) {
         ImmutableMap.Builder<String, Object> options = BeamHttpClient.getArgumentsBuilder();
 
-        if (attributes != null) {
-            for (Map.Entry<ShowChannelsResponse.Attributes, ShowChannelsResponse.Ordering> entry : attributes.entrySet()) {
-                options.put(Enums.serializedName(entry.getKey()), Enums.serializedName(entry.getValue()));
-            }
-        }
-
-        if (only != null) {
-            options.put("only", Enums.serializedName(only));
+        if (ordering != null) {
+            options.put("order", ordering.build());
         }
 
         options.put("page", Math.max(0, page));

--- a/src/main/java/pro/beam/api/util/StringUtil.java
+++ b/src/main/java/pro/beam/api/util/StringUtil.java
@@ -1,0 +1,24 @@
+package pro.beam.api.util;
+
+
+import java.util.Iterator;
+
+public class StringUtil {
+    //XXX: Java 8 has a built in way of doing this, We still support Java 7.
+    /**
+     * Join an Iterable of String into one string with a separator
+     * @param source
+     * @param separator
+     */
+    public static String join( Iterable<String> source, String separator ) {
+        Iterator<String> iterator = source.iterator();
+        if (source == null || !iterator.hasNext()) {
+            return "";
+        }
+        StringBuilder builder = new StringBuilder(iterator.next());
+        while (iterator.hasNext()) {
+            builder.append(separator).append(iterator.next());
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/pro/beam/api/test/unit/http/SortOrderMapTest.java
+++ b/src/test/java/pro/beam/api/test/unit/http/SortOrderMapTest.java
@@ -1,0 +1,16 @@
+package pro.beam.api.test.unit.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+import pro.beam.api.http.SortOrderMap;
+import pro.beam.api.response.channels.ShowChannelsResponse;
+
+public class SortOrderMapTest {
+    @Test public void itBuildsAValidOrderParameter() {
+        SortOrderMap<ShowChannelsResponse.Attributes,ShowChannelsResponse.Ordering> map = new SortOrderMap<>();
+        map.put(ShowChannelsResponse.Attributes.VIEWERS_TOTAL, ShowChannelsResponse.Ordering.ASCENDING);
+        map.put(ShowChannelsResponse.Attributes.FOLLOWERS, ShowChannelsResponse.Ordering.DESCENDING);
+        String res = map.build();
+        Assert.assertEquals("followers:desc,viewersTotal:asc",res);
+    }
+}

--- a/src/test/java/pro/beam/api/test/unit/http/SortOrderMapTest.java
+++ b/src/test/java/pro/beam/api/test/unit/http/SortOrderMapTest.java
@@ -11,6 +11,6 @@ public class SortOrderMapTest {
         map.put(ShowChannelsResponse.Attributes.VIEWERS_TOTAL, ShowChannelsResponse.Ordering.ASCENDING);
         map.put(ShowChannelsResponse.Attributes.FOLLOWERS, ShowChannelsResponse.Ordering.DESCENDING);
         String res = map.build();
-        Assert.assertEquals("followers:desc,viewersTotal:asc",res);
+        Assert.assertEquals("viewersTotal:asc,followers:desc",res);
     }
 }


### PR DESCRIPTION
Looks like the channels service was written quite a long time ago the api has completely changed since then regarding sorting etc.

This resolves just the channel endpoint in regards to the updated api. A more indepth look at the client is planned for the next sprint.

This is blocking developer lab tutorials :(
