### PR TITLE
JWT parse failure and unit test fixes

### DIFF
--- a/src/main/java/pro/beam/api/http/BeamHttpClient.java
+++ b/src/main/java/pro/beam/api/http/BeamHttpClient.java
@@ -1,7 +1,5 @@
 package pro.beam.api.http;
 
-import com.auth0.jwt.internal.org.bouncycastle.util.encoders.Base64;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +24,7 @@ import pro.beam.api.BeamAPI;
 import pro.beam.api.resource.user.JSONWebToken;
 import pro.beam.api.services.impl.JWTService;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -304,7 +303,7 @@ public class BeamHttpClient {
         }
 
         return this.beam.gson.fromJson(
-                new String(Base64.decode(parts[1])),
+                new String(DatatypeConverter.parseBase64Binary(parts[1])),
                 JSONWebToken.class);
     }
 

--- a/src/test/java/pro/beam/api/test/unit/http/BeamHttpClientTest.java
+++ b/src/test/java/pro/beam/api/test/unit/http/BeamHttpClientTest.java
@@ -2,6 +2,7 @@ package pro.beam.api.test.unit.http;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.gson.Gson;
 import org.apache.http.*;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import pro.beam.api.BeamAPI;
 import pro.beam.api.http.BeamHttpClient;
 import pro.beam.api.resource.BeamUser;
+import pro.beam.api.resource.user.JSONWebToken;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -24,6 +26,8 @@ import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
+import static pro.beam.api.http.BeamHttpClient.CSRF_TOKEN_HEADER;
+import static pro.beam.api.http.BeamHttpClient.X_JWT_HEADER;
 
 public class BeamHttpClientTest {
     private HttpClient defaultHttpClient;
@@ -38,14 +42,14 @@ public class BeamHttpClientTest {
     }
 
     @Test
-    public void itHandlesCSRF() throws IOException, ExecutionException, InterruptedException {
+    public void itHandlesCSRF() {
         beamAPI = new BeamAPI();
         defaultHttpClient = mock(HttpClient.class);
 
         // This is done because Mockito is not able to mock methods that are called within the class'
         // Constructor.
         class MockableBeamHttpClient extends BeamHttpClient {
-            public MockableBeamHttpClient(BeamAPI beam) {
+            private MockableBeamHttpClient(BeamAPI beam) {
                 super(beam);
             }
 
@@ -58,15 +62,20 @@ public class BeamHttpClientTest {
 
 
         HttpResponse csrfResponse = prepareResponse(461, "{\"error\":\"Invalid or missing CSRF header, see details here: <https://dev.beam.pro/rest.html#csrf>\",\"statusCode\":461}");
-        csrfResponse.addHeader(new BasicHeader(beamHttpClient.CSRF_TOKEN_HEADER, "abc123"));
+        csrfResponse.addHeader(new BasicHeader(CSRF_TOKEN_HEADER, "abc123"));
         csrfResponse.setEntity(mock(HttpEntity.class));
 
         HttpResponse okResponse = prepareResponse(200, "{\"id\":314,\"userId\":344,\"token\":\"Beam\",\"online\":false,\"featured\":false,\"partnered\":false,\"transcodingProfileId\":1,\"suspended\":false,\"name\":\"Weekly Updates and more!\"}");
-        csrfResponse.addHeader(new BasicHeader(beamHttpClient.CSRF_TOKEN_HEADER, "abc123"));
+        okResponse.addHeader(new BasicHeader(CSRF_TOKEN_HEADER, "abc123"));
 
-        when(defaultHttpClient.execute(any(HttpUriRequest.class), isNull(HttpContext.class)))
-                .thenReturn(csrfResponse)
-                .thenReturn(okResponse);
+        try {
+            doReturn(csrfResponse)
+                    .doReturn(okResponse)
+                    .when(defaultHttpClient)
+                    .execute(any(HttpUriRequest.class), isNull(HttpContext.class));
+        } catch (IOException e) {
+            Assert.fail();
+        }
 
         Futures.addCallback(beamHttpClient.get("/channels/314", BeamUser.class, null), new FutureCallback<BeamUser>() {
             @Override
@@ -91,5 +100,63 @@ public class BeamHttpClientTest {
             throw new IllegalArgumentException(e);
         }
         return response;
+    }
+
+    @Test
+    public void itHandlesJWT() {
+        beamAPI = new BeamAPI();
+        defaultHttpClient = mock(HttpClient.class);
+
+        final String jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjU3NDk5NSwiYnR5cCI6ImdyYW50IiwiZ3JvdXBzIjpbeyJpZCI6MSwibmFtZSI6IlVzZXIiLCJVc2VyR3JvdXAiOnsiZ3JvdXBJZCI6MSwidXNlcklkIjo1NzQ5OTV9fV0sImlhdCI6MTQ4MTE0NDQ0NywiZXhwIjoxNTEyNjgwNDQ3LCJpc3MiOiJCZWFtIiwianRpIjoiVGhpcyBpc24ndCBhIHJlYWwgc2Vzc2lvbi4ifQ==.HkL5xq-eivwCk5OgczgIu5s_NFFxdQAKH9Jfb906aT4";
+
+        final JSONWebToken.Group jwtGroup = new JSONWebToken.Group();
+        jwtGroup.id = 1L;
+        jwtGroup.name = "User";
+
+        final JSONWebToken jwt = new JSONWebToken();
+        jwt.exp = 1512680447L;
+        jwt.iat = 1481144447L;
+        jwt.iss = "Beam";
+        jwt.jti = "This isn't a real session.";
+        jwt.sub = 574995L;
+        jwt.btyp = "grant";
+        jwt.groups = new JSONWebToken.Group[]{jwtGroup};
+
+        // This is done because Mockito is not able to mock methods that are called within the class'
+        // Constructor.
+        class MockableBeamHttpClient extends BeamHttpClient {
+            private MockableBeamHttpClient(BeamAPI beam) {
+                super(beam);
+            }
+
+            @Override
+            protected HttpClient buildHttpClient() {
+                return defaultHttpClient;
+            }
+        }
+
+        beamHttpClient = new MockableBeamHttpClient(beamAPI);
+
+        HttpResponse okResponse = prepareResponse(200, "{\"id\":314,\"userId\":344,\"token\":\"Beam\",\"online\":false,\"featured\":false,\"partnered\":false,\"transcodingProfileId\":1,\"suspended\":false,\"name\":\"Weekly Updates and more!\"}");
+        okResponse.addHeader(new BasicHeader(X_JWT_HEADER, jwtString));
+
+        try {
+            doReturn(okResponse).when(defaultHttpClient).execute(any(HttpUriRequest.class), isNull(HttpContext.class));
+        } catch (IOException e) {
+            Assert.fail();
+        }
+
+        Futures.addCallback(beamHttpClient.get("/channels/314", BeamUser.class, null), new FutureCallback<BeamUser>() {
+            @Override
+            public void onSuccess(BeamUser beamUser) {
+                Assert.assertEquals(beamHttpClient.getJWTString(), jwtString);
+                Assert.assertEquals(beamHttpClient.getJwt(), jwt);
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                Assert.fail();
+            }
+        });
     }
 }


### PR DESCRIPTION
Found this issue when I was working on the XBL sign in flow.
- Fixed issue
- Added unit test for this flow
- Fixed other unit test (it was 'passing' by swallowing an exception and never evaluating the assertions)