### PR TITLE
Fixing user following errors

### DIFF
--- a/src/main/java/pro/beam/api/response/users/UserFollowsResponse.java
+++ b/src/main/java/pro/beam/api/response/users/UserFollowsResponse.java
@@ -1,8 +1,8 @@
 package pro.beam.api.response.users;
 
-import pro.beam.api.resource.BeamUser;
+import pro.beam.api.resource.channel.BeamChannel;
 
 import java.util.ArrayList;
 
-public class UserFollowsResponse extends ArrayList<BeamUser> {
+public class UserFollowsResponse extends ArrayList<BeamChannel> {
 }

--- a/src/main/java/pro/beam/api/services/impl/UsersService.java
+++ b/src/main/java/pro/beam/api/services/impl/UsersService.java
@@ -96,7 +96,7 @@ public class UsersService extends AbstractHTTPService {
     }
 
     public ListenableFuture<UserFollowsResponse> following(BeamUser user, int page, int limit) {
-        return this.post(user.id + "/follows",
+        return this.get(user.id + "/follows",
                          UserFollowsResponse.class,
                          BeamHttpClient.getArgumentsBuilder()
                                  .put("page", Math.max(0, page))


### PR DESCRIPTION
Previously, the following method was returning a post to the
users/follows endpoint, which doesn't exist. Changing it to return a get
to the same endpoint fixes this.
With that fix, the endpoint now returns a list of channels, but
UserFollowsResponse extended an arraylist of Users instead. Updating the
extended arraylist template fixes the returned data to match what it's
supposed to be.