### PR TITLE
Ensure Timer cancellation on connect

### DIFF
--- a/src/main/java/pro/beam/api/resource/constellation/ws/BeamConstellationConnectable.java
+++ b/src/main/java/pro/beam/api/resource/constellation/ws/BeamConstellationConnectable.java
@@ -62,6 +62,10 @@ public class BeamConstellationConnectable {
      * Handles the automatic ping to the socket.
      */
     private void handlePing() {
+        if (pingTimer != null) { 
+            pingTimer.cancel();
+        }
+
         pingTimer = (new Timer());
         pingTimer.schedule(new TimerTask() {
             @Override


### PR DESCRIPTION
We are getting a lot of crashes that appear to be originating from the leak of thousands of timers being created. While I haven't been able to reproduce this directly yet, this particular code seems to be suspect as given it is a public method, there is no guarantee any in place timers would be cancelled. 