### PR TITLE
docs(*): Build and publish docs to gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Futures.addCallback(mixer.use(UsersService.class).search("tta"), new ResponseHan
     }
 });
 ```
+## Developing
+
+### Docs
+
+To build and publish the docs run:
+`mvn javadoc:javadoc scm-publish:publish-scm`

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
         <java-websocket.version>1.3.1-SNAPSHOT</java-websocket.version>
         <junit.version>4.11</junit.version>
         <powermock.version>1.9.0-rc1</powermock.version>
+
+        <scm-publish.scmBranch>gh-pages</scm-publish.scmBranch>
+        <scm-publish.pubScmUrl>scm:git:git@github.com:mixer/beam-client-java.git</scm-publish.pubScmUrl>
+        <scm-publish.repoUrl>https://github.com/mixer/beam-client-java</scm-publish.repoUrl>
+
+        <scm-publish.siteDocOuputDirectory>${project.build.directory}/site/apidocs</scm-publish.siteDocOuputDirectory>
     </properties>
 
     <dependencies>
@@ -75,6 +81,12 @@
             <url>https://maven.mixer.com/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+    <scm>
+        <connection>${scm-publish.pubScmUrl}</connection>
+        <url>${scm-publish.repoUrl}</url>
+        <developerConnection>${scm-publish.pubScmUrl}</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
         <plugins>
@@ -122,6 +134,22 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-publish-plugin</artifactId>
+                <version>1.0</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <checkoutDirectory>${scmPublish.checkoutDirectory}</checkoutDirectory>
+                    <checkinComment>Publishing Site Docs for ${project.artifactId}:${project.version}
+                    </checkinComment>
+                    <!-- Plugins defaults to "target/staging" and since the distributionManagement section is a pain in the ass for site docs, this is easier -->
+                    <content>${scm-publish.siteDocOuputDirectory}</content>
+                    <skipDeletedFiles>true</skipDeletedFiles>
+                    <pubScmUrl>${scm-publish.pubScmUrl}</pubScmUrl>
+                    <scmBranch>${scm-publish.scmBranch}</scmBranch>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,7 @@
                 <inherited>true</inherited>
                 <configuration>
                     <checkoutDirectory>${scmPublish.checkoutDirectory}</checkoutDirectory>
-                    <checkinComment>Publishing Site Docs for ${project.artifactId}:${project.version}
-                    </checkinComment>
-                    <!-- Plugins defaults to "target/staging" and since the distributionManagement section is a pain in the ass for site docs, this is easier -->
+                    <checkinComment>Publishing Site Docs for ${project.artifactId}:${project.version}</checkinComment>
                     <content>${scm-publish.siteDocOuputDirectory}</content>
                     <skipDeletedFiles>true</skipDeletedFiles>
                     <pubScmUrl>${scm-publish.pubScmUrl}</pubScmUrl>


### PR DESCRIPTION
In a subsequent PR to the developer site i'll remove the java doc generation. This will make the developer site significantly easier to develop for. The developer site will then link to the gh-pages of this repo.

We should do this for interactive-java too, its coooool!

Used: https://dzone.com/articles/how-publish-maven-site-docs

To work out how to do this.