### PR TITLE
Simple fix for use of different timedate format in users endpoint

### DIFF
--- a/src/main/java/com/mixer/api/http/MixerHttpClient.java
+++ b/src/main/java/com/mixer/api/http/MixerHttpClient.java
@@ -236,7 +236,9 @@ public class MixerHttpClient {
         // Allow a null response to be given back, such that we return a ListenableFuture
         // with null.
         if (type != null && completeResponse.body != null) {
-            return this.mixer.gson.fromJson(completeResponse.body(), type);
+        	String result = completeResponse.body;
+        	result = result.replaceAll("[+|-][0-1][0-9]:[0-5][0-9]", ".000Z");
+            return this.mixer.gson.fromJson(result, type);
         } else {
             return null;
         }


### PR DESCRIPTION
Fix the following error, seems https://mixer.com/api/v1/users  ISO 8601 format for timedate got changed

```
Caused by: com.google.gson.JsonSyntaxException: java.io.IOException: mixer: unable to parse date (2015-03-18T22:46:16+00:00)
    at com.google.gson.Gson.fromJson(Gson.java:818)
    at com.google.gson.Gson.fromJson(Gson.java:768)
    at com.google.gson.Gson.fromJson(Gson.java:717)
    at com.google.gson.Gson.fromJson(Gson.java:689)
    at com.mixer.api.http.MixerHttpClient.handleResponse(MixerHttpClient.java:239)
    at com.mixer.api.http.MixerHttpClient.handleRequest(MixerHttpClient.java:218)
    at com.mixer.api.http.MixerHttpClient$2.call(MixerHttpClient.java:205)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```