### PR TITLE
Fix to add ISO8601 Date formats in addition to RFC822 format

### DIFF
--- a/src/main/java/com/mixer/api/util/gson/DateAdapter.java
+++ b/src/main/java/com/mixer/api/util/gson/DateAdapter.java
@@ -85,9 +85,10 @@ public class DateAdapter extends TypeAdapter<Date> {
     public static DateAdapter v1() {
         DateFormat defaultFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         DateFormat newFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        DateFormat ISOFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
 
         return new DateAdapter(
-                ImmutableList.of(defaultFormat, newFormat),
+                ImmutableList.of(defaultFormat, newFormat, ISOFormat),
                 defaultFormat
         );
     }


### PR DESCRIPTION
The previous DateAdapter code only implemented a local and RFC822 date format. When presented with a ISO8601 date the code would return an exception due to not knowing how to parse it from the limited date formats. This will add ISO8601 formatting to allow java clients to continue functioning with the current date format and future ISO8601 compliant date formats